### PR TITLE
Make example config not loopy

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -12,7 +12,7 @@
 		"log_hits": true
 	},
 	"domains": {
-		"example.com": {
+		"example.net": {
 			"match_subdomains": true,
 			"rewrites": [
 				{


### PR DESCRIPTION
It's not necessarily loopy, assuming www.example.com has a different A record, but it's still not great practice to have a redirect-to-self possible.