### PR TITLE
Add `client_ip_header` configuration option

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -2,6 +2,7 @@
 	"listen_address": ":8080",
 	"metrics_address": ":9091",
 	"metrics_path": "/metrics",
+	"client_ip_header": "Fly-Client-IP",
 	"default_response": {
 		"code": 421,
 		"body": "421 Misdirected Request\n\nTarget URI does not match an origin for which the server has been configured.\n",

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -13,6 +13,7 @@ type Config struct {
 	ListenAddress   string            `json:"listen_address"`
 	MetricsAddress  string            `json:"metrics_address"`
 	MetricsPath     string            `json:"metrics_path"`
+	ClientIPHeader  string            `json:"client_ip_header" note:"Read the client IP address from this HTTP header, instead of Request.RemoteAddr (ignored if header is empty or not present)"`
 	DefaultResponse *DefaultResponse  `json:"default_response"`
 	Domains         map[string]Domain `json:"domains" note:"Keys must be valid fully qualified DNS domain names in ASCII lower case and punycode if required."`
 }

--- a/server/server.go
+++ b/server/server.go
@@ -28,7 +28,11 @@ func MakeHandler(config *configuration.Config, metrics *Metrics) func(http.Respo
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), configFromContext, config)
 		ctx = context.WithValue(ctx, metricsFromContext, metrics)
-		handler(w, r.WithContext(ctx))
+		req := r.WithContext(ctx)
+		if config.ClientIPHeader != "" && r.Header.Get(config.ClientIPHeader) != "" {
+			req.RemoteAddr = r.Header.Get(config.ClientIPHeader)
+		}
+		handler(w, req)
 	}
 }
 


### PR DESCRIPTION
This allows `RemoteAddr` to be set to the value of an incoming request header, rather than being the remote address of the connection. This is useful in circumstances where this app sits behind a reverse proxy which forwards the original IP address.